### PR TITLE
adding logic for warning on sites in maintenance

### DIFF
--- a/check_http.sh
+++ b/check_http.sh
@@ -146,6 +146,7 @@ checkopen(){
 	RES=$(${GREP} -i ${STRING} ${TMPFILE})
 	if [ "$?" -ne "0" ];
 	then
+                # String was not found. Check if the site is in maintenance
 		MAINTENANCE_RES=$(${GREP} -i MAINTENANCE ${TMPFILE})
                 if [ "$?" -eq "0" ];
                 then

--- a/check_http.sh
+++ b/check_http.sh
@@ -24,6 +24,8 @@ RM=/bin/rm
 
 # Temp file
 WGETOUT=/tmp/wgetoutput
+MAINTENANCE='<div class="maintenance-title">Sorry down for maintenance.</div><div class="maintenance-description">We’re currently working to make things better, we’ll be back shortly.</div>'
+
 
 ### Functions
 # Check dependencies and paths
@@ -144,8 +146,15 @@ checkopen(){
 	RES=$(${GREP} -i ${STRING} ${TMPFILE})
 	if [ "$?" -ne "0" ];
 	then
-		echo "String ${STRING} not found in ${URL}"
-		STATUS=CRITICAL
+		MAINTENANCE_RES=$(${GREP} -i MAINTENANCE ${TMPFILE})
+                if [ "$?" -eq "0" ];
+                then
+                        echo "${FULLURL} is in maintenance mode"
+                        STATUS=WARNING
+                else
+                        echo "String ${STRING} not found in ${URL}"
+                        STATUS=CRITICAL
+                fi
 		${RM} -f ${TMPFILE}
 		output
 	fi


### PR DESCRIPTION
I was able to test this on the `monitor01` host by running the script manually like so:

```bash
root@monitor01:/nagios/custom-plugins# ./check_arsalan_http.sh -w 12 -c 60 -H img.rvguide.com -u /maintenance.htm -s "this string does not exist on the page"
http://img.rvguide.com/maintenance.htm is in maintenance mode
RESPONSE: WARNING - |Response=ms;12000;60000;0
```